### PR TITLE
Improve performance when unmarshalling long vectors

### DIFF
--- a/xcb.el
+++ b/xcb.el
@@ -207,7 +207,7 @@ Concurrency is disabled as it breaks the orders of errors, replies and events."
         (when (<= 8 (length cache)) ;at least setup header is available
           (let ((data-len (+ 8 (* 4 (funcall (if xcb:lsb 'xcb:-unpack-u2-lsb
                                                'xcb:-unpack-u2)
-                                             (substring cache 6 8)))))
+                                             cache 6))))
                 obj)
             (when (>= (length cache) data-len)
               (xcb:-log "Setup response: %s" cache)
@@ -241,7 +241,7 @@ Concurrency is disabled as it breaks the orders of errors, replies and events."
              (xcb:-log "Error received: %s" (substring cache 0 32))
              (let ((sequence (funcall (if xcb:lsb 'xcb:-unpack-u2-lsb
                                         'xcb:-unpack-u2)
-                                      (substring cache 2 4)))
+                                      cache 2))
                    (plist (slot-value connection 'error-plist))
                    struct)
                (when (plist-member plist sequence)
@@ -256,7 +256,7 @@ Concurrency is disabled as it breaks the orders of errors, replies and events."
             (1                          ;reply
              (let* ((reply-words (funcall (if xcb:lsb 'xcb:-unpack-u4-lsb
                                             'xcb:-unpack-u4)
-                                          (substring cache 4 8)))
+                                          cache 4))
                     (reply-length (+ 32 (* 4 reply-words)))
                     struct sequence plist)
                (when (< (length cache) reply-length) ;too short, do next time
@@ -264,7 +264,7 @@ Concurrency is disabled as it breaks the orders of errors, replies and events."
                (xcb:-log "Reply received: %s" (substring cache 0 reply-length))
                (setq sequence (funcall (if xcb:lsb 'xcb:-unpack-u2-lsb
                                          'xcb:-unpack-u2)
-                                       (substring cache 2 4)))
+                                       cache 2))
                (setq plist (slot-value connection 'reply-plist))
                (setq struct (plist-get plist sequence))
                (when struct


### PR DESCRIPTION
I noticed quite poor performance of `xcb:keysyms:init` (in excess of five seconds to run with the CPU at its slowest speed), and while I realize performance has not been a major concern so far, I believe this is worth fixing. It's due to this code in xcb-types.el:

```
        (dotimes (i list-size)
          (setq tmp (xcb:-unmarshal-field obj x data nil))
          (setq result (nconc result (list (car tmp))))
          (setq data (substring data (cadr tmp)))
          (setq count (+ count (cadr tmp))))
```

That's really inefficient if `data` is quite long, because `substring` doesn't appear to perform any optimizations in this case, so we perform O(n²) copying operations.

This patch avoids using `substring` and passes around the current offset into the `data` vector instead; that makes the code slightly more complicated, but I believe it is worth it as performance improves drastically. The critical code section turns into:

```
        (dotimes (i list-size)
          (setq tmp (xcb:-unmarshal-field obj x data (+ offset count) nil))
          (setq result (nconc result (list (car tmp))))
          (setq count (+ count (cadr tmp))))
```

with no modification of `data`.

Note that a corresponding change is needed in xelb-util: https://github.com/ch11ng/xelb-util/compare/master...pipcet:data-offset?expand=1

What do you think? I understand if you decide not to apply this patch because the complication isn't worth the performance gain, but I believe that it is.
