### PR TITLE
Fix assertion error

### DIFF
--- a/xcb-icccm.el
+++ b/xcb-icccm.el
@@ -133,7 +133,7 @@ This method automatically format the value as 8, 16 or 32 bits array."
           (setf value nil)              ;no available value
         (setq tmp (substring value
                              0          ;long-offset
-                             (- (length value) bytes-after))
+                             (length value))
               value nil)
         (pcase format
           (8


### PR DESCRIPTION
SDL 2 applications trigger this assertion.
It seems that in most cases (even SDL 1.2) the substring
calculated during the unmarshalling is always the whole
sequence length, except with SDL 2, which becomes
a sequence of size 0.
Always using the whole sequence does not seem
to cause any problem, while being able to handle
a wider range of applications.
